### PR TITLE
k parameter not passed on to impute.knn

### DIFF
--- a/R/champ.impute.R
+++ b/R/champ.impute.R
@@ -27,7 +27,7 @@ champ.impute <- function(beta=myLoad$beta,
 
         beta <- tmp_beta[rowValid,]
         if(!is.null(pd)) pd <- pd[colValid,]
-        data.m <- impute.knn(beta)$data
+        data.m <- impute.knn(beta,k=k)$data
         message("(3): The rest NA are imputed by KNN method which parameter k as ",k,".")
     }else if(method=="Delete")
     {


### PR DESCRIPTION
When the method is set to "Combine" the k parameter was not passed on to the impute.knn function, resulting in the default of k = 10 always being used.