### PR TITLE
Avoid error from rowMeans() if there is only one DMP

### DIFF
--- a/R/champ.DMP.R
+++ b/R/champ.DMP.R
@@ -135,7 +135,8 @@ champ.DMP <- function(beta = myNorm,
         com.idx <- intersect(rownames(DMPs[[i]]),rownames(probe.features))
         if(!is.null(Compare))
         {
-            avg <-  cbind(rowMeans(beta[com.idx,which(pheno==Compare[[i]][1])]),rowMeans(beta[com.idx,which(pheno==Compare[[i]][2])]))
+            avg <- cbind(rowMeans(beta[com.idx, pheno==Compare[[i]][1], drop=FALSE]),
+                         rowMeans(beta[com.idx, pheno==Compare[[i]][2], drop=FALSE]))
             avg <- cbind(avg,avg[,2]-avg[,1])
             colnames(avg) <- c(paste(Compare[[i]],"AVG",sep="_"),"deltaBeta")
             DMPs[[i]] <- data.frame(DMPs[[i]][com.idx,],avg,probe.features[com.idx,])


### PR DESCRIPTION
When running `champ.DMP()`, if there is only one differentially expressed probe, the following fails:

```
avg <-  cbind(rowMeans(beta[com.idx,which(pheno==Compare[[i]][1])]),
              rowMeans(beta[com.idx,which(pheno==Compare[[i]][2])]))
```

because `com.idx` has length 1, and `beta[com.idx,which(pheno==Compare[[i]][1])]` instead of a matrix becomes a vector, over which cannot be computed row names. By adding `drop=FALSE`, we can make it return a matrix with one row, and the operation works.

In the patch I've also removing the use of `which()` as it seems unnecessary. The only case where it would make a difference is if `pheno` or `Compare` contain NAs, but I don't know if that is actually possible. In case, I can put the 'which()' back.