### PR TITLE
Update champ.SVD.R to work with R >= 4.0

### DIFF
--- a/R/champ.SVD.R
+++ b/R/champ.SVD.R
@@ -108,7 +108,7 @@ champ.SVD <- function(beta=myNorm,
 
     if(length(which(is.na(beta)))>0) message(length(which(is.na(beta)))," NA are detected in your beta Data Set, which may cause fail or uncorrect of SVD analysis. You may want to impute NA with champ.impute() function first.")
 
-    if(class(beta) == 'data.frame')
+    if(inherits(beta, 'data.frame'))
     {
         message("Your beta parameter is data.frame format. ChAMP is now changing it to matrix.")
         beta <- as.matrix(beta)


### PR DESCRIPTION
Checking class(beta) will return "matrix" and "array" (if beta is a matrix) since R 4.0.0, breaking champ.SVD.

https://cran.r-project.org/doc/manuals/r-release/NEWS.html "matrix objects now also inherit from class "array", so e.g., class(diag(1)) is c("matrix", "array"). This invalidates code incorrectly assuming that class(matrix_obj)) has length one."

Checking with inherits work before and after 4.0.0.